### PR TITLE
Add project classifiers and URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,15 @@ requires-python = ">=3.8"
 authors = [{ name = "Your Name" }]
 license = { text = "MIT" }
 dependencies = []
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Framework :: Pytest",
+]
+
+[project.urls]
+Homepage = "https://github.com/greg-baker-public/pytest-stepthrough"
+Repository = "https://github.com/greg-baker-public/pytest-stepthrough"
+Issues = "https://github.com/greg-baker-public/pytest-stepthrough/issues"
 
 [project.entry-points.pytest11]
 stepthrough = "pytest_stepthrough.plugin"


### PR DESCRIPTION
## Summary
- specify Python 3 and Pytest metadata classifiers in pyproject
- declare project homepage, repository, and issue tracker URLs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc35c7f248324a20d41d727f71d93