### PR TITLE
Add skip-existing to PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true
       - name: Upload release assets
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
- avoid errors when re-uploading release files by enabling `skip-existing`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dd3cf57ac8324a8768d5c0ac02e78